### PR TITLE
Fix crate name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "tremor"
+name = "librespot-tremor"
 version = "0.1.0"
 authors = ["Paul Lietar <paul@lietar.net>"]
 


### PR DESCRIPTION
The [tremor crate](https://crates.io/crates/tremor) has nothing to do with librespot-tremor. However, `Cargo.toml` currently uses that incorrect name.

If I try to add a `librespot-tremor = { git = "https://github.com/John2143/librespot-tremor" }` override to librespot's or spotifyd's `Cargo.toml`, I get the following error due to the name mismatch:

```
error: no matching package named `librespot-tremor` found
location searched: https://github.com/John2143/librespot-tremor
required by package `spotifyd v0.2.25 (/home/matias/git/spotifyd/src/spotifyd-0.2.25)`
```

This PR renames the crate to librespot-tremor (its correct name) to fix the issue.